### PR TITLE
change required node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version": "0.1.0",
     "private": true,
     "engines": {
-        "node": ">=16"
+        "node": ">=14"
     },
     "scripts": {
         "dev": "next dev",


### PR DESCRIPTION
Changing due to vercel error

```
Error: Found invalid Node.js Version: ">=16". Please set "engines": { "node": "14.x" } in your `package.json` file to use Node.js 14. Learn More: http://vercel.link/node-version
```