### PR TITLE
Add translated strings and messages support

### DIFF
--- a/app/views/Home.tsx
+++ b/app/views/Home.tsx
@@ -1,17 +1,22 @@
 import { OnlineStatusProvider } from '../utils/useOnlineStatus';
 import { useA2HS } from 'react-use-a2hs';
 import { usePrismicData } from '../../libs/Prismic/components/PrismicDataProvider';
+import Message from '../../libs/Prismic/components/Message';
 import React from 'react';
+import String from '../../libs/Prismic/components/String';
 
 const Home = () => {
     const [promptEvent, promptToInstall] = useA2HS();
 
-    usePrismicData({ list: true });
+    usePrismicData();
 
     return (
         <OnlineStatusProvider>
             <div>
-                Welcome home
+                <p style={{ color: 'red' }}>
+                    <String id="learnAndEarn" />
+                </p>
+                <Message id="communityFundsWillRunOut" />
                 <div>
                     <p>check console...</p>
                     {promptEvent && (

--- a/libs/Prismic/components/Message.tsx
+++ b/libs/Prismic/components/Message.tsx
@@ -1,18 +1,25 @@
 import { usePrismicData } from './PrismicDataProvider';
+import { useRouter } from 'next/router';
 import React from 'react';
 import RichText, { RichTextProps } from './RichText';
 import isEmpty from 'lodash/isEmpty';
+import localesConfig from '../../../locales.config';
+
+const defaultLocale = localesConfig.find(({ isDefault }) => isDefault)?.code?.toLowerCase() || 'en-us';
 
 type Props = { id: string } & RichTextProps;
 
 const Message = (props: Props) => {
+    const { locale } = useRouter();
     const { id, ...forwardProps } = props;
 
-    const { messages } = usePrismicData();
+    const { translations } = usePrismicData();
 
-    const content = messages?.[id] as any;
+    const content = (translations?.[locale.toLowerCase()]?.messages?.[id] || translations?.[defaultLocale]?.messages?.[id]) as any;
 
     if (isEmpty(content)) {
+        console.log(`No message rich text found with the key "${id}"!`);
+
         return null;
     }
 

--- a/libs/Prismic/components/PrismicDataProvider.tsx
+++ b/libs/Prismic/components/PrismicDataProvider.tsx
@@ -1,4 +1,3 @@
-import { RichTextField } from '@prismicio/types';
 import React, { createContext } from 'react';
 import baseConfig from '../../../config';
 import extractFromData from '../helpers/extractFromData';
@@ -58,7 +57,7 @@ export const usePrismicData = (options: UsePrismicDataOptions = {}) => {
         config,
         modals,
         userConfig,
-        translations: translationsFromProps,
+        translations,
         ...forwardData
     } = parsedKeysObject || {};
 
@@ -67,12 +66,6 @@ export const usePrismicData = (options: UsePrismicDataOptions = {}) => {
     if (viewName) {
         delete forwardData?.[viewName];
     }
-
-    const translations = extractFromData(translationsFromProps?.data, 'string');
-    const messages = extractFromData(
-        translationsFromProps?.data,
-        'message'
-    ) as { [key: string]: RichTextField };
 
     const extractFromConfig = (key: string) =>
         extractFromData(config?.data || {}, key);
@@ -92,7 +85,6 @@ export const usePrismicData = (options: UsePrismicDataOptions = {}) => {
         console.log(`Data from prismic\n`, {
             config,
             data: dataToExport,
-            messages,
             modals,
             translations,
             url,
@@ -107,7 +99,6 @@ export const usePrismicData = (options: UsePrismicDataOptions = {}) => {
         extractFromConfig,
         extractFromModals,
         extractFromView,
-        messages,
         modals,
         translations,
         url,

--- a/libs/Prismic/components/String.tsx
+++ b/libs/Prismic/components/String.tsx
@@ -1,0 +1,29 @@
+import React, { FC } from 'react';
+import parse from '../helpers/parse';
+import useTranslations from '../hooks/useTranslations';
+
+type Props = {
+  children?: any;
+  components?: { [key: string]: FC };
+  id: string;
+  variables?: { [key: string]: string | number };
+};
+
+const String = (props: Props) => {
+  const { children, components, id, variables } = props;
+  const { t } = useTranslations();
+
+  const string = t(id, variables);
+
+  if (typeof children === 'function') {
+    return children(parse(string, components));
+  }
+
+  return (
+    <>
+      {parse(string, components)}
+    </>
+  )
+}
+
+export default String;

--- a/libs/Prismic/helpers/extractTranslations.ts
+++ b/libs/Prismic/helpers/extractTranslations.ts
@@ -1,0 +1,17 @@
+import { PrismicDocument } from '@prismicio/types';
+import extractFromData from './extractFromData';
+import keysToCamel from './keysToCamel';
+
+const extractTranslations = (documents: PrismicDocument[]) => {
+    const translations = documents.filter(({ type }) => type === 'pwa-translations').reduce((results, document) => ({
+        ...results,
+        [document?.lang]: {
+            messages: extractFromData(keysToCamel(document?.data), 'message'),
+            strings: extractFromData(keysToCamel(document?.data), 'string')
+        }
+    }), {});
+
+    return { translations }
+}
+
+export default extractTranslations;

--- a/libs/Prismic/helpers/getTypesToFetchWithConfigs.ts
+++ b/libs/Prismic/helpers/getTypesToFetchWithConfigs.ts
@@ -1,9 +1,0 @@
-const getTypesToFetchWithConfigs = (types?: string[]) => [
-    'pwa-config',
-    'pwa-modals',
-    'pwa-translations',
-    'pwa-user-config',
-    ...(types || [])
-];
-
-export default getTypesToFetchWithConfigs;

--- a/libs/Prismic/hooks/useTranslations.tsx
+++ b/libs/Prismic/hooks/useTranslations.tsx
@@ -1,0 +1,27 @@
+import { usePrismicData } from '../components/PrismicDataProvider';
+import { useRouter } from 'next/router';
+import bracked from '../helpers/bracked';
+import localesConfig from '../../../locales.config';
+
+const defaultLocale = localesConfig.find(({ isDefault }) => isDefault)?.code?.toLowerCase() || 'en-us';
+
+const useTranslations = () => {
+  const { locale } = useRouter();
+  const { translations } = usePrismicData();
+
+  const t = (id: string, variables = {} as { [key: string]: string | number }) => {
+    const string = translations?.[locale.toLowerCase()]?.strings?.[id] || translations?.[defaultLocale]?.strings?.[id];
+
+    if (!string) {
+      console.log(`No translation find for the key "${id}"!`);
+
+      return ''
+    }
+
+    return bracked(string, variables);
+  };
+
+  return { t };
+};
+
+export default useTranslations;

--- a/pages/beneficiary.tsx
+++ b/pages/beneficiary.tsx
@@ -2,16 +2,13 @@ import { ClientConfig } from '@prismicio/client';
 import { GetStaticProps } from 'next';
 import Beneficiary from '../app/views/Beneficiary';
 import Prismic from '../libs/Prismic/Prismic';
-import getTypesToFetchWithConfigs from '../libs/Prismic/helpers/getTypesToFetchWithConfigs';
 
 export const getStaticProps: GetStaticProps = async ({
     locale: lang,
     previewData
 }) => {
     const clientOptions = previewData as ClientConfig;
-    const types = getTypesToFetchWithConfigs(['pwa-view-beneficiary']);
-
-    const data = await Prismic.getByTypes({ clientOptions, lang, types });
+    const data = await Prismic.getByTypes({ clientOptions, lang, types: 'pwa-view-beneficiary' });
 
     return {
         props: {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,16 +2,14 @@ import { ClientConfig } from '@prismicio/client';
 import { GetStaticProps } from 'next';
 import Home from '../app/views/Home';
 import Prismic from '../libs/Prismic/Prismic';
-import getTypesToFetchWithConfigs from '../libs/Prismic/helpers/getTypesToFetchWithConfigs';
 
 export const getStaticProps: GetStaticProps = async ({
     locale: lang,
     previewData
 }) => {
     const clientOptions = previewData as ClientConfig;
-    const types = getTypesToFetchWithConfigs(['pwa-view-beneficiary']);
 
-    const data = await Prismic.getByTypes({ clientOptions, lang, types });
+    const data = await Prismic.getByTypes({ clientOptions, lang, types: 'pwa-view-beneficiary' });
 
     return {
         props: {

--- a/pages/profile.tsx
+++ b/pages/profile.tsx
@@ -2,16 +2,14 @@ import { ClientConfig } from '@prismicio/client';
 import { GetStaticProps } from 'next';
 import Prismic from '../libs/Prismic/Prismic';
 import Profile from '../app/views/Profile';
-import getTypesToFetchWithConfigs from '../libs/Prismic/helpers/getTypesToFetchWithConfigs';
 
 export const getStaticProps: GetStaticProps = async ({
     locale: lang,
     previewData
 }) => {
     const clientOptions = previewData as ClientConfig;
-    const types = getTypesToFetchWithConfigs(['pwa-view-profile']);
 
-    const data = await Prismic.getByTypes({ clientOptions, lang, types });
+    const data = await Prismic.getByTypes({ clientOptions, lang, types: 'pwa-view-profile' });
 
     return {
         props: {

--- a/prismic.config.js
+++ b/prismic.config.js
@@ -11,6 +11,13 @@ const apiEndpoint = `https://${repoName}.cdn.prismic.io/api/v2`;
 // eslint-disable-next-line no-process-env
 const accessToken = process.env.PRISMIC_KEY;
 
+const configDocuments = [
+    'pwa-config',
+    'pwa-modals',
+    'pwa-translations',
+    'pwa-user-config'
+]
+
 // TODO
 // -- Route Resolver rules
 // Manages the url links to internal Prismic documents two levels deep (optionals)
@@ -24,6 +31,6 @@ const accessToken = process.env.PRISMIC_KEY;
 // };
 const Router = { routes: [] };
 
-const prismicConfiguration = { Router, accessToken, apiEndpoint, repoName };
+const prismicConfiguration = { Router, accessToken, apiEndpoint, configDocuments, repoName };
 
 module.exports = prismicConfiguration;


### PR DESCRIPTION
This PR adds support to handle the Prismic document `Translations`. It adds the following:
- `useTranslations` hook that exposes a function (`t`) to fetch a string  from an id
- `String` component to allow a simple string translation inside JSX component.
- `Message` component that consumes the `messages` from the `Translations` Prismic document.

All have a fallback by key / id. This means that if you pass an ID that don't exist on a particular language, it will fallback to the main language: `en-us`. 