### PR TITLE
Implement api requests retry on timeout error

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,22 +1,44 @@
 // Or from '@reduxjs/toolkit/query' if not using the auto-generated hooks
+import { FetchArgs } from '@reduxjs/toolkit/dist/query/fetchBaseQuery'
 import { RootState } from '../state/store';
-import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+import { createApi, fetchBaseQuery, retry } from '@reduxjs/toolkit/query/react';
 import config from '../../config';
+
+const baseQuery = retry(
+    async (args: string | FetchArgs, api, extraOptions) => {
+      const result = 
+        await fetchBaseQuery({ 
+            baseUrl: config.baseApiUrl,
+            prepareHeaders: (headers, { getState }) => {
+                const { token } = (getState() as RootState).auth;
+    
+                // If we have a token set in state, let's assume that we should be passing it.
+                if(token) {
+                    headers.set('authorization', `Bearer ${token}`);
+                }
+    
+                return headers;
+            }
+        })(
+            args,
+            api,
+            extraOptions
+        )
+
+        // If the error returned is different than 408 (timeout), we don't wan't to try again
+        if(result.error && result.error?.status !== 408) {
+            retry.fail(result.error); 
+        }
+
+        return result;
+    },
+    {
+      maxRetries: 5
+    }
+  )
 
 // initialize an empty api service that we'll inject endpoints into later as needed
 export const emptySplitApi = createApi({
-    baseQuery: fetchBaseQuery({
-        baseUrl: config.baseApiUrl,
-        prepareHeaders: (headers, { getState }) => {
-            const { token } = (getState() as RootState).auth;
-
-            // If we have a token set in state, let's assume that we should be passing it.
-            if (token) {
-                headers.set('authorization', `Bearer ${token}`);
-            }
-
-            return headers;
-        }
-    }),
+    baseQuery,
     endpoints: () => ({})
 });

--- a/src/views/Beneficiary.tsx
+++ b/src/views/Beneficiary.tsx
@@ -17,7 +17,8 @@ import String from '../libs/Prismic/components/String';
 
 const Beneficiary: React.FC<{ isLoading?: boolean }> = props => {
     const { isLoading } = props;
-    const [loading, toggleLoading] = useState(false);
+    const [loadingButton, toggleLoadingButton] = useState(false);
+    const [loadingCommunity, toggleLoadingCommunity] = useState(true);
     const [claimAllowed, toggleClaim] = useState(false);
     const [community, setCommunity] = useState('');
     
@@ -44,6 +45,8 @@ const Beneficiary: React.FC<{ isLoading?: boolean }> = props => {
                 const community = await getCommunity(auth?.user?.beneficiary?.community).unwrap();
 
                 setCommunity(community?.name);
+
+                toggleLoadingCommunity(false);
             } 
             catch (error) {
                 console.log(error);
@@ -62,9 +65,9 @@ const Beneficiary: React.FC<{ isLoading?: boolean }> = props => {
     );
         
     const claimFunds = () => {
-        toggleLoading(true);
+        toggleLoadingButton(true);
 
-        claim().then(() => toggleLoading(false)).catch(() => { toggleLoading(false); toggleClaim(false); });
+        claim().then(() => toggleLoadingButton(false)).catch(() => { toggleLoadingButton(false); toggleClaim(false); });
     };
 
     const allowClaim = () => toggleClaim(true);
@@ -78,7 +81,7 @@ const Beneficiary: React.FC<{ isLoading?: boolean }> = props => {
     const claimAmountDisplay = currencyFormat(claimAmount, currency);
 
     return (
-        <ViewContainer isLoading={!isReady || isLoading}>
+        <ViewContainer isLoading={!isReady || isLoading || loadingCommunity}>
             <Display>
                 {title}
             </Display>
@@ -108,7 +111,7 @@ const Beneficiary: React.FC<{ isLoading?: boolean }> = props => {
                                         }
                                         {
                                             (isClaimable || claimAllowed) &&
-                                            <Button default isLoading={loading} large onClick={claimFunds}>
+                                            <Button default isLoading={loadingButton} large onClick={claimFunds}>
                                                 <String id="claim" /> ~{claimAmountDisplay}
                                             </Button>
                                         }


### PR DESCRIPTION
Added a retry component to the API requests.

If a error is returned and the code is 408 (timeout), than the request will be resent up to 5 times.

Any other error code, returns immediately.  