### PR TITLE
Add Welcome modal in Beneficiary page

### DIFF
--- a/src/api/community.ts
+++ b/src/api/community.ts
@@ -3,6 +3,7 @@ import { emptySplitApi } from './index';
 interface Community {
     name: string;
     currency: string;
+    coverImage: string;
 };
 
 // Define a service using a base URL and expected endpoints

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -22,6 +22,16 @@ interface PutPostUser {
 // Define a service using a base URL and expected endpoints
 export const userApi = emptySplitApi.injectEndpoints({
     endpoints: builder => ({
+        // Accept beneficiary community rules
+        acceptRules: builder.mutation<void, void>({
+            query: () => ({
+                body: {
+                    'action': 'beneficiary-rules'
+                },
+                method: 'PATCH',
+                url: 'users'
+            })
+        }),
         // First connect. Either register or login.
         createUser: builder.mutation<User, PutPostUser>({
             query: body => ({
@@ -54,6 +64,7 @@ export const userApi = emptySplitApi.injectEndpoints({
 // Export hooks for usage in functional components, which are
 // auto-generated based on the defined endpoints
 export const {
+    useAcceptRulesMutation,
     useCreateUserMutation,
     useGetUserMutation,
     useUpdateUserMutation

--- a/src/modals/CommunityRules.tsx
+++ b/src/modals/CommunityRules.tsx
@@ -5,8 +5,8 @@ import React from 'react';
 import RichText from '../libs/Prismic/components/RichText';
 
 const Rules = () => {
-    const { handleClose } = useModal();
-    const { extractFromModals } = usePrismicData({ list: true });
+    const { handleClose, acceptCommunityRules, communityName } = useModal();
+    const { extractFromModals } = usePrismicData();
 
     const { buttonLabel, content, items, title } = extractFromModals('communityRules') as any;
 
@@ -15,7 +15,7 @@ const Rules = () => {
             <Display medium>
                 {title}
             </Display>
-            <RichText content={content} g500 mt={0.5} small />
+            <RichText content={content} g500 mt={0.5} small variables={{ community: communityName }}/>
             <Box mt={2}>
                 <Row colSpan={2}>
                     {items.map(({ icon, title, text }: any, index: number) => (
@@ -30,7 +30,7 @@ const Rules = () => {
                 </Row>
             </Box>
             <Box fLayout="end" mt={2} right w="100%">
-                <Button fluid="xs" onClick={handleClose}>
+                <Button fluid="md" onClick={() => { acceptCommunityRules(); handleClose(); }}>
                     {buttonLabel}
                 </Button>
             </Box>

--- a/src/modals/WelcomeBeneficiary.tsx
+++ b/src/modals/WelcomeBeneficiary.tsx
@@ -1,0 +1,29 @@
+import { Avatar, Box, Button, ModalWrapper, openModal, useModal } from '@impact-market/ui';
+import { usePrismicData } from '../libs/Prismic/components/PrismicDataProvider';
+import React from 'react';
+import RichText from '../libs/Prismic/components/RichText';
+
+const Welcome = () => {
+    const { acceptCommunityRules, communityName, communityImage } = useModal();
+    const { extractFromModals } = usePrismicData();
+
+    const { buttonLabel, content, title } = extractFromModals('welcomeBeneficiary') as any;
+
+    return (
+        <ModalWrapper maxW={25} padding={1.5} w="100%">
+            {
+                communityImage &&
+                <Avatar large margin="auto" mb={1.5} url={communityImage} />
+            }
+            <RichText center content={title} large medium variables={{ community: communityName }} />
+            <RichText base center content={content} g500 mt={0.5} />
+            <Box mt={1.5} w="100%">
+                <Button fluid="xs" onClick={() => openModal('communityRules', { acceptCommunityRules, communityName })}>
+                    {buttonLabel}
+                </Button>
+            </Box>
+        </ModalWrapper>
+    )
+}
+
+export default Welcome;

--- a/src/modals/index.ts
+++ b/src/modals/index.ts
@@ -1,7 +1,8 @@
 import dynamic from 'next/dynamic';
 
 const modals = {
-    communityRules: dynamic(() => import('./CommunityRules'), { ssr: false })
+    communityRules: dynamic(() => import('./CommunityRules'), { ssr: false }),
+    welcomeBeneficiary: dynamic(() => import('./WelcomeBeneficiary'), { ssr: false })
 }
 
 export default modals;


### PR DESCRIPTION
On first entering the Beneficiary page, the user must accept the rules.

- Open a modal informing about the rules;
- On closing the first modal, a second opens with the rules itself;
- On close, send request to update the user field "beneficiaryRules" to "true";