### PR TITLE
Fixed small bug when entering Beneficiaries & Managers pages

### DIFF
--- a/src/views/Beneficiaries/index.tsx
+++ b/src/views/Beneficiaries/index.tsx
@@ -42,7 +42,9 @@ const Beneficiaries: React.FC<{ isLoading?: boolean }> = props => {
     const communityBeneficiaries = useQuery(getCommunityBeneficiaries, { variables: { address: auth?.user?.manager?.community } });
 
     useEffect(() => {
-        router.push('/manager/beneficiaries?state=active', undefined, { shallow: true });
+        if(!getByKey('state')) {
+            router.push('/manager/beneficiaries?state=active', undefined, { shallow: true });
+        }
 
         const init = async () => {
             try {

--- a/src/views/Managers/index.tsx
+++ b/src/views/Managers/index.tsx
@@ -43,7 +43,9 @@ const Beneficiaries: React.FC<{ isLoading?: boolean }> = props => {
     const communityManagers = useQuery(getCommunityManagers, { variables: { address: auth?.user?.manager?.community } });
 
     useEffect(() => {
-        router.push('/manager/managers?state=active', undefined, { shallow: true });
+        if(!getByKey('state')) {
+            router.push('/manager/managers?state=active', undefined, { shallow: true });
+        }
 
         const init = async () => {
             try {


### PR DESCRIPTION
- When entering the Beneficiaries & Managers pages, we add a filter "state=active" but only if it doesn't already exist in the URL