### PR TITLE
Feature: Add Community

### DIFF
--- a/src/helpers/handleSignature.ts
+++ b/src/helpers/handleSignature.ts
@@ -3,7 +3,7 @@ import config from '../../config';
 
 export const handleSignature = async (signMessage: any) => {
     try {
-        const timestamp = new Date().getTime().toString();
+        const timestamp = new Date()?.getTime()?.toString();
         const messageToSign = `${config.signatureMessage} ${timestamp}`;
 
         await signMessage(messageToSign).then((signature: string) => {

--- a/src/helpers/handleSignature.ts
+++ b/src/helpers/handleSignature.ts
@@ -14,6 +14,6 @@ export const handleSignature = async (signMessage: any) => {
     } catch (error) {
         console.log(error);
 
-        return { success: false };
+        throw Error;
     }
 };

--- a/src/hooks/useWallet.tsx
+++ b/src/hooks/useWallet.tsx
@@ -3,7 +3,7 @@ import { AppContext } from '../components/WrapperProvider';
 import { getAddress } from '@ethersproject/address';
 import { getUserTypes } from '../utils/users';
 import { removeCookies, setCookies } from 'cookies-next';
-import { removeCredentials, setCredentials } from '../state/slices/auth';
+import { removeCredentials, setCredentials, setSignature } from '../state/slices/auth';
 import { useCreateUserMutation } from '../api/user';
 import { useDispatch } from 'react-redux';
 import React from 'react';
@@ -75,6 +75,12 @@ const useWallet = () => {
             removeCookies('AUTH_TOKEN', { path: '/' });
             removeCookies('SIGNATURE', { path: '/' });
             removeCookies('MESSAGE', { path: '/' });
+
+            dispatch(setSignature({
+                    message: null,
+                    signature: null
+                })
+            )
 
             if (!!callback) {
                 await callback();

--- a/src/modals/AddCommunity/ConfirmAdd.tsx
+++ b/src/modals/AddCommunity/ConfirmAdd.tsx
@@ -1,8 +1,17 @@
 /* eslint-disable no-nested-ternary */
-import { Box, Button, CircledIcon, ModalWrapper, Text, useModal } from '@impact-market/ui';
+import { Box, Button, CircledIcon, ModalWrapper, Text, toast, useModal } from '@impact-market/ui';
+import { SubmitHandler, useForm } from 'react-hook-form';
+import { addUserSchema } from '../../utils/communities';
 import { currencyFormat } from '../../utils/currencies';
+import { handleSignature } from "../../helpers/handleSignature";
+import { selectCurrentUser } from '../../state/slices/auth';
 import { usePrismicData } from '../../libs/Prismic/components/PrismicDataProvider';
-import React from 'react';
+import { useSelector } from 'react-redux';
+import { useSignatures } from '@impact-market/utils/useSignatures';
+import { useYupValidationResolver } from '../../helpers/yup';
+import Message from '../../libs/Prismic/components/Message';
+import PersonalForm from '../../views/AddCommunity/PersonalForm';
+import React, { useState } from 'react';
 import RichText from '../../libs/Prismic/components/RichText';
 import String from '../../libs/Prismic/components/String';
 import useTranslations from '../../libs/Prismic/hooks/useTranslations';
@@ -10,38 +19,122 @@ import useTranslations from '../../libs/Prismic/hooks/useTranslations';
 const ConfirmAdd = () => {
     const { data, handleClose, isSubmitting, language, onSubmit } = useModal();
 
+    const { signature } = useSelector(selectCurrentUser);
+    const { signMessage } = useSignatures();
+    const auth = useSelector(selectCurrentUser);
+    const [updatedData, setUpdatedData] = useState(data) as any
+    const [profilePicture, setProfilePicture] = useState(null);
+
     const localeCurrency = new Intl.NumberFormat(language, {
         currency: 'USD',
         style: 'currency'
     });
 
     const { t } = useTranslations();
-    const { extractFromModals } = usePrismicData();
+    const { extractFromModals, extractFromView } = usePrismicData();
     const { beneficiaryAble, content, title } = extractFromModals('createAddCommunity') as any;
+    const { basicProfileData } = extractFromView('formSections') as any;
+
 
     const amount = currencyFormat(data.claimAmount, localeCurrency);
     const interval = data.baseInterval === 'day' ? t('perDay') : data.baseInterval === 'week' ? t('perWeek') : '';
     const maxAmount = currencyFormat(data.maxClaim, localeCurrency);
     const minutes = data.incrementInterval;
 
+    const { handleSubmit, control, formState: { errors, submitCount, isValid } } = useForm({
+        defaultValues: {
+            address: auth?.user?.address || '',
+            email: auth?.user?.email || '',
+            firstName: auth?.user?.firstName || '',
+            lastName: auth?.user?.lastName || '',
+            profileImg: auth?.user?.avatarMediaPath || ''
+        },
+        mode: "onChange",
+        resolver: useYupValidationResolver(addUserSchema)
+    });
+
+    const personalForm: SubmitHandler<any> = async (userData) => {
+        if (isValid) {
+            try {
+                if (!signature){
+                    const { success } = await handleSignature(signMessage);
+                    
+                    if (success && (profilePicture || auth?.user?.avatarMediaPath)) {
+                        setUpdatedData({...data, ...userData})
+                    }
+                } else if (profilePicture || auth?.user?.avatarMediaPath) {
+                    setUpdatedData({...data, ...userData})
+                }
+            } catch (error: any) {
+                if (error?.data?.error?.name === 'EXPIRED_SIGNATURE') {           
+                    const { success } = await handleSignature(signMessage);
+                    
+                    if (success) personalForm(data);
+                } else {
+                    console.log(error);
+                    toast.error(<Message id="errorOccurred" />);
+                }
+            }
+        }  
+    }
+
+    const authData = (!auth?.user?.email || !auth?.user?.firstName || !auth?.user?.lastName || !auth?.user?.avatarMediaPath)
+    const personalData = (!updatedData?.email || !updatedData?.firstName || !updatedData?.lastName)
+
     return (
-        <ModalWrapper maxW={25} padding={1.5} w="100%">
-            <CircledIcon icon="checkCircle" medium success /> 
-            <Text g900 large mt={1.25} semibold>{title}</Text>
-            <RichText content={content} g500 mt={0.5} small />
-            <RichText content={beneficiaryAble} g500 mt={1.25} variables={{ amount, interval, maxAmount, minutes }} />
-            <Box flex mt={2}>
-                <Box pr={0.375} w="50%">
-                    <Button disabled={isSubmitting} gray onClick={handleClose} w="100%">
-                        <String id="goBack" />
-                    </Button>
+        <ModalWrapper maxW={30} padding={1.5} w="100%">
+            {authData && personalData ?
+                <>
+                <CircledIcon icon="user" medium success /> 
+                <Text g900 large mt={1.25} semibold>{basicProfileData[0]?.text}</Text>
+                <Box flex>
+                    <form onSubmit={handleSubmit(personalForm)} style={{ width: '100%' }}>
+                        <Box mt={1.25}>
+                            <PersonalForm
+                                control={control}
+                                errors={errors}
+                                isLoading={isSubmitting}
+                                profilePicture={profilePicture}
+                                setProfilePicture={setProfilePicture}
+                                submitCount={submitCount}
+                                user={auth?.user}
+                            />
+                        </Box>
+                        <Box flex mt={2}>
+                            <Box pr={0.375} w="50%">
+                                <Button disabled={isSubmitting} gray onClick={handleClose} w="100%">
+                                    <String id="goBack" />
+                                </Button>
+                            </Box>
+                            <Box pl={0.375} w="50%">
+                                <Button disabled={isSubmitting} isLoading={isSubmitting} onClick={() => personalForm(data)} w="100%">
+                                    <String id="submit" />
+                                </Button>
+                            </Box>
+                        </Box>
+                    </form>
                 </Box>
-                <Box pl={0.375} w="50%">
-                    <Button disabled={isSubmitting} isLoading={isSubmitting} onClick={() => { onSubmit(data); handleClose(); }} w="100%">
-                        <String id="iConfirm" />
-                    </Button>
+                </>
+            :
+                <>
+                <CircledIcon icon="checkCircle" medium success /> 
+                <Text g900 large mt={1.25} semibold>{title}</Text>
+                <RichText content={content} g500 mt={0.5} small />
+                <RichText content={beneficiaryAble} g500 mt={1.25} variables={{ amount, interval, maxAmount, minutes }} />
+                <Box flex mt={2}>
+                    <Box pr={0.375} w="50%">
+                        <Button disabled={isSubmitting} gray onClick={handleClose} w="100%">
+                            <String id="cancel" />
+                        </Button>
+                    </Box>
+                    <Box pl={0.375} w="50%">
+                        <Button disabled={isSubmitting} isLoading={isSubmitting} onClick={() => { onSubmit(updatedData, auth, profilePicture && profilePicture); handleClose(); }} w="100%">
+                            <String id="iConfirm" />
+                        </Button>
+                    </Box>
                 </Box>
-            </Box>
+                </>
+            }
         </ModalWrapper>
     )
 }

--- a/src/modals/AddCommunity/ConfirmAdd.tsx
+++ b/src/modals/AddCommunity/ConfirmAdd.tsx
@@ -24,7 +24,6 @@ const ConfirmAdd = () => {
     const auth = useSelector(selectCurrentUser);
     const [updatedData, setUpdatedData] = useState(data) as any
     const [profilePicture, setProfilePicture] = useState(null);
-    const [hasPersonalData, setHasPersonalData] = useState(false);
 
     const localeCurrency = new Intl.NumberFormat(language, {
         currency: 'USD',
@@ -61,13 +60,9 @@ const ConfirmAdd = () => {
                     await handleSignature(signMessage);
                 }
 
-                setUpdatedData({...data, ...userData})
-
-                const authData = (!auth?.user?.email || !auth?.user?.firstName || !auth?.user?.lastName || !auth?.user?.avatarMediaPath)
-                const personalData = (!updatedData?.email || !updatedData?.firstName || !updatedData?.lastName)
-            
-                setHasPersonalData(authData && personalData);
-
+                if (profilePicture || auth?.user?.avatarMediaPath) {
+                    setUpdatedData({...data, ...userData})
+                }
             } catch (error: any) {
                 if (error?.data?.error?.name === 'EXPIRED_SIGNATURE' || error?.data?.error?.name === 'INVALID_SINATURE' ) {           
                     const { success } = await handleSignature(signMessage);
@@ -81,14 +76,17 @@ const ConfirmAdd = () => {
         }  
     }
 
+    const authData = (!auth?.user?.email || !auth?.user?.firstName || !auth?.user?.lastName || !auth?.user?.avatarMediaPath)
+    const personalData = (!updatedData?.email || !updatedData?.firstName || !updatedData?.lastName)
+
     return (
         <ModalWrapper maxW={30} padding={1.5} w="100%">
-            { !hasPersonalData ?
+            {authData && personalData ?
                 <>
                     <CircledIcon icon="user" medium success /> 
                     <Text g900 large mt={1.25} semibold>{basicProfileData[0]?.text}</Text>
                     <Box flex>
-                        <form onSubmit={handleSubmit(() => personalForm)} style={{ width: '100%' }}>
+                        <form onSubmit={handleSubmit(personalForm)} style={{ width: '100%' }}>
                             <Box mt={1.25}>
                                 <PersonalForm
                                     control={control}
@@ -107,7 +105,7 @@ const ConfirmAdd = () => {
                                     </Button>
                                 </Box>
                                 <Box pl={0.375} w="50%">
-                                    <Button disabled={isSubmitting} isLoading={isSubmitting} onClick={() => personalForm(data)} w="100%">
+                                    <Button disabled={isSubmitting} isLoading={isSubmitting} type="submit" w="100%">
                                         <String id="submit" />
                                     </Button>
                                 </Box>

--- a/src/utils/communities.ts
+++ b/src/utils/communities.ts
@@ -29,7 +29,7 @@ export const getExpectedUBIDuration = (claimAmountWatch: string, maxClaimWatch: 
     };
 }
 
-export const addCommunitySchema = yup.object().shape({
+export const editCommunitySchema = yup.object().shape({
     baseInterval: yup.string().required(),
     claimAmount: yup.number().required().positive().min(0),
     description: yup.string().min(240).max(2048).required(),
@@ -41,6 +41,23 @@ export const addCommunitySchema = yup.object().shape({
     maxBeneficiaries: yup.number().positive().integer().min(0).max(100000).nullable(true),
     maxClaim: yup.number().moreThan(yup.ref('claimAmount'), 'Max claim must be bigger than claim amount.').required(),
     name: yup.string().required()
+});
+
+export const addCommunitySchema = yup.object().shape({
+    baseInterval: yup.string().required(),
+    claimAmount: yup.number().required().positive().min(0),
+    description: yup.string().min(240).max(2048).required(),
+    incrementInterval: yup.number().required().positive().integer().min(0),
+    location: yup.mixed().required(),
+    maxBeneficiaries: yup.number().positive().integer().min(0).max(100000).nullable(true),
+    maxClaim: yup.number().moreThan(yup.ref('claimAmount'), 'Max claim must be bigger than claim amount.').required(),
+    name: yup.string().required()
+});
+
+export const addUserSchema = yup.object().shape({
+    email: yup.string().required().matches(emailRegExp).email(),
+    firstName: yup.string().required(),
+    lastName: yup.string().required(),
 });
 
 export const editValidCommunitySchema = yup.object().shape({

--- a/src/utils/currencies.tsx
+++ b/src/utils/currencies.tsx
@@ -58,7 +58,7 @@ export function getCurrencySymbol(currency: string) {
                 symbol_native: string;
             };
         }
-    )[currency.toUpperCase()].symbol;
+    )[currency?.toUpperCase()]?.symbol;
 }
 
 export const convertCurrency = (number: number, rates: Rate[], from: string, to: string) => {

--- a/src/utils/routes.ts
+++ b/src/utils/routes.ts
@@ -1,8 +1,8 @@
 export type Routes = string[];
 
-export const publicRoutes: Routes = ['/', '/stories', '/proposals', '/communities', '/communities/[id]', '/notifications', '/messages'];
+export const publicRoutes: Routes = ['/', '/stories', '/proposals', '/communities', '/communities/[id]', '/notifications', '/messages', '/manager/communities/add'];
 
-export const privateRoutes: Routes = ['/profile', '/settings', '/manager/communities/add', '/mycommunity'];
+export const privateRoutes: Routes = ['/profile', '/settings', '/mycommunity'];
 
 export const demoRoutes: Routes = [];
 

--- a/src/views/AddCommunity/PersonalForm.tsx
+++ b/src/views/AddCommunity/PersonalForm.tsx
@@ -1,131 +1,126 @@
 /* eslint-disable no-nested-ternary */
-import { Box, Card, Col, Divider, Row, Text, Thumbnail } from '@impact-market/ui';
+import { Box, Col, Divider, Row, Text, Thumbnail } from '@impact-market/ui';
 import { PutPostUser } from '../../api/user';
 import { usePrismicData } from '../../libs/Prismic/components/PrismicDataProvider';
 import Input from '../../components/Input';
 import InputUpload from '../../components/InputUpload';
-import React from 'react';
+import React, { useState } from 'react';
 import RichText from '../../libs/Prismic/components/RichText';
 import String from '../../libs/Prismic/components/String';
 import useTranslations from '../../libs/Prismic/hooks/useTranslations';
 
-const PersonalForm: React.FC<{ control: any, errors: any, isLoading: boolean, user: PutPostUser, profileImage: any, setProfileImage: Function, submitCount: number }> = props => {
-    const { control, errors, isLoading, profileImage, setProfileImage, submitCount, user } = props;
+const PersonalForm: React.FC<{ control: any, errors: any, isLoading: boolean, user: PutPostUser, profilePicture: any, setProfilePicture: Function, submitCount: number }> = props => {
+    const { control, errors, isLoading, profilePicture, setProfilePicture, submitCount, user } = props;
     const { t } = useTranslations();
 
     const { extractFromView } = usePrismicData();
-    const { communityImageDescription, communityImageUpload, managerDetails, basicProfileData } = extractFromView('formSections') as any;
+    const { communityImageDescription, communityImageUpload } = extractFromView('formSections') as any;
+
+    const [profilePictureThumbnail, setProfilePictureThumbnail] = useState(null);
     
-    const handleProfileImage = (event: any) => {
+    const handleProfilePicture = (event: any) => {
         if(event?.length > 0) {
-            setProfileImage(event[0]);
+            setProfilePicture(event[0]);
+            setProfilePictureThumbnail(event[0]);
         }
     };
 
     // TODO: check what link to add and how to add the links in "Learn to choose a photo" text
-    // TODO: add texts to view in Prismic
 
     return (
-        <Row>
-            <Col colSize={{ sm: 4, xs: 12 }} pb={1.25} pt={{ sm: 1.25, xs: 0 }}>
-                <Divider margin="1.25 0" show={{ sm: 'none', xs: 'block' }} />
-                <Text g700 medium small>{managerDetails}</Text>
-                <RichText content={basicProfileData} g700 medium small />
-            </Col>
-            <Col colSize={{ sm: 8, xs: 12 }} pb={1.25} pt={{ sm: 1.25, xs: 0 }}>
-                <Card padding={1.5}>
-                    {
-                        !user?.avatarMediaPath &&
-                        <Box>
-                            <Text g700 mb={0.25} medium small><String id="yourProfilePhoto" /></Text>
-                            <RichText content={communityImageDescription} g500 mb={0.5} small />
-                            <InputUpload
-                                accept={['image/png', 'image/jpeg']}
-                                control={control}
+        <Box>
+            <Divider/>
+            {
+                !user?.avatarMediaPath &&
+                <Box>
+                    <Text g700 mb={0.25} medium small><String id="yourProfilePhoto" /></Text>
+                    <RichText content={communityImageDescription} g500 mb={0.5} small />
+                    <InputUpload
+                        accept={['image/png', 'image/jpeg']}
+                        control={control}
+                        disabled={isLoading}
+                        handleFiles={handleProfilePicture}
+                        hint={submitCount > 0 && !profilePicture ? t('fieldRequired') : ''}
+                        label={<RichText content={communityImageUpload} g500 regular small variables={{ height: 300, width: 300 }} />}
+                        multiple={false}
+                        name="profileImg"
+                        withError={submitCount > 0 && !profilePicture}
+                    />
+                    {!!profilePictureThumbnail && (
+                        <Box mt={0.75}>
+                            <Thumbnail
                                 disabled={isLoading}
-                                handleFiles={handleProfileImage}
-                                hint={submitCount > 0 && !profileImage ? t('fieldRequired') : ''}
-                                label={<RichText content={communityImageUpload} g500 regular small variables={{ height: 300, width: 300 }} />}
-                                multiple={false}
-                                name="profileImg"
-                                withError={submitCount > 0 && !profileImage}
+                                h={10}
+                                handleClick={(event: any) => {
+                                    event.preventDefault();
+                                    setProfilePicture(null);
+                                    setProfilePictureThumbnail(null)
+                                }}
+                                icon="trash"
+                                url={URL.createObjectURL(profilePictureThumbnail)}
+                                w={10}
                             />
-                            {!!profileImage && (
-                                <Box mt={0.75}>
-                                    <Thumbnail
-                                        disabled={isLoading}
-                                        h={10}
-                                        handleClick={(event: any) => {
-                                            event.preventDefault();
-                                            setProfileImage(null);
-                                        }}
-                                        icon="trash"
-                                        url={URL.createObjectURL(profileImage)}
-                                        w={10}
-                                    />
-                                </Box>
-                            )}
                         </Box>
-                    }
+                    )}
+                </Box>
+            }
+            {
+                (!user?.firstName || !user?.lastName) &&
+                <Row mt={!user?.avatarMediaPath ? 1.5 : 0}>
                     {
-                        (!user?.firstName || !user?.lastName) &&
-                        <Row mt={!user?.avatarMediaPath ? 1.5 : 0}>
-                            {
-                                !user?.firstName &&
-                                <Col colSize={{ sm: 6, xs: 12 }} pb={{ sm: 0, xs: 0.75 }} pt={0}>
-                                    <Input
-                                        control={control}
-                                        disabled={isLoading}
-                                        hint={
-                                            errors?.firstName?.message?.key ?
-                                            t(errors?.firstName?.message?.key)?.replace('{{ value }}', errors?.firstName?.message?.value) :
-                                            errors?.firstName ?
-                                            t('fieldRequired') :
-                                            ''
-                                        }
-                                        label={t('firstName')}
-                                        name="firstName"
-                                        withError={!!errors?.firstName}
-                                    />
-                                </Col>
-                            }
-                            {
-                                !user?.lastName &&
-                                <Col colSize={{ sm: 6, xs: 12 }} pt={{ sm: 0, xs: 0.75 }}>
-                                    <Input
-                                        control={control}
-                                        disabled={isLoading}
-                                        hint={
-                                            errors?.lastName?.message?.key ?
-                                            t(errors?.lastName?.message?.key)?.replace('{{ value }}', errors?.lastName?.message?.value) :
-                                            errors?.lastName ?
-                                            t('fieldRequired') :
-                                            ''
-                                        }
-                                        label={t('lastName')}
-                                        name="lastName"
-                                        withError={!!errors?.lastName}
-                                    />
-                                </Col>
-                            }
-                        </Row>
-                    }
-                    {
-                        !user?.email &&
-                        <Box mt={!user?.avatarMediaPath || !user?.firstName || !user?.lastName ? 1.5 : 0}>
+                        !user?.firstName &&
+                        <Col colSize={{ sm: 6, xs: 12 }} pb={{ sm: 0, xs: 0.75 }} pt={0}>
                             <Input
                                 control={control}
                                 disabled={isLoading}
-                                hint={errors?.email ? t('errorEmail') : ''}
-                                label={t('email')}
-                                name="email"
-                                withError={!!errors?.email}
+                                hint={
+                                    errors?.firstName?.message?.key ?
+                                    t(errors?.firstName?.message?.key)?.replace('{{ value }}', errors?.firstName?.message?.value) :
+                                    errors?.firstName ?
+                                    t('fieldRequired') :
+                                    ''
+                                }
+                                label={t('firstName')}
+                                name="firstName"
+                                withError={!!errors?.firstName}
                             />
-                        </Box>
+                        </Col>
                     }
-                </Card>
-            </Col>
-        </Row>
+                    {
+                        !user?.lastName &&
+                        <Col colSize={{ sm: 6, xs: 12 }} pt={{ sm: 0, xs: 0.75 }}>
+                            <Input
+                                control={control}
+                                disabled={isLoading}
+                                hint={
+                                    errors?.lastName?.message?.key ?
+                                    t(errors?.lastName?.message?.key)?.replace('{{ value }}', errors?.lastName?.message?.value) :
+                                    errors?.lastName ?
+                                    t('fieldRequired') :
+                                    ''
+                                }
+                                label={t('lastName')}
+                                name="lastName"
+                                withError={!!errors?.lastName}
+                            />
+                        </Col>
+                    }
+                </Row>
+            }
+            {
+                !user?.email &&
+                <Box mt={!user?.avatarMediaPath || !user?.firstName || !user?.lastName ? 1.5 : 0}>
+                    <Input
+                        control={control}
+                        disabled={isLoading}
+                        hint={errors?.email ? t('errorEmail') : ''}
+                        label={t('email')}
+                        name="email"
+                        withError={!!errors?.email}
+                    />
+                </Box>
+            }
+        </Box>
     );
 };
 

--- a/src/views/AddCommunity/index.tsx
+++ b/src/views/AddCommunity/index.tsx
@@ -177,7 +177,7 @@ const AddCommunity: React.FC<{ isLoading?: boolean }> = props => {
                 city = data.location?.label?.lastIndexOf(',')
             }
 
-            // Add Community    dubai - pais
+            // Add Community
             const payload = {
                 city: data.location?.label?.substring(0, city)?.trim() || data.location?.label,
                 contractParams: {

--- a/src/views/AddCommunity/index.tsx
+++ b/src/views/AddCommunity/index.tsx
@@ -110,11 +110,11 @@ const AddCommunity: React.FC<{ isLoading?: boolean }> = props => {
         if (!!communityImage) {
             if (!auth?.user) {
                 try {
-                    await connect()
+                    await connect();
                 } catch (error) { 
-                    console.log(error)
+                    console.log(error);
                 }
-            } 
+            }
 
             if (auth?.user) {
                 openModal('confirmAddCommunity', { data, isSubmitting, language, onSubmit });
@@ -261,7 +261,7 @@ const AddCommunity: React.FC<{ isLoading?: boolean }> = props => {
                     </Box>
                     <Box mt={{ sm: 0, xs: 1 }} tAlign={{ sm: 'right', xs: 'left' }} w={{ sm: '25%', xs: '100%' }}>
                         <Button disabled={isSubmitting} icon="send" isLoading={isSubmitting} type="submit" w={{ sm: 'auto', xs: '100%' }}>
-                            <String id="submit" />
+                            {auth?.user ? <String id="submit" /> : <String id="connectWallet" />}
                         </Button>
                     </Box>
                 </Box>

--- a/src/views/Communities/Header.tsx
+++ b/src/views/Communities/Header.tsx
@@ -13,17 +13,15 @@ import Link from 'next/link';
 import Message from '../../libs/Prismic/components/Message';
 import RichText from '../../libs/Prismic/components/RichText';
 import useTranslations from '../../libs/Prismic/hooks/useTranslations';
-import useWallet from '../../hooks/useWallet';
 
 const Header = ({ activeTab, supportingCountries, supportingCommunities, user }: any) => {
     const { extractFromView } = usePrismicData();
     const { title, content } = extractFromView('heading') as any;
     const { t } = useTranslations();
-    const { address } = useWallet();
 
     return (
         <Row>
-            <Col colSize={{ sm: (!user?.roles?.length) ? 6 : 12, xs: 12 }}>
+            <Col colSize={{ sm: 6, xs: 12 }}>
                 <Display g900 medium>
                     {title}
                 </Display>
@@ -50,16 +48,13 @@ const Header = ({ activeTab, supportingCountries, supportingCommunities, user }:
                 </Box>
             </Col>
 
-            {/* If user role is empty (which means he's a donor), show Add Community button */}
-            {!user?.roles?.length && !!address &&
-                <Col colSize={{ sm: 6, xs: 12 }} pt={{ sm: 1, xs: 0 }} tAlign={{ sm: 'right', xs: 'left' }}>
-                    <Link href="/manager/communities/add" passHref>
-                        <Button icon="plus">
-                            {t('addCommunity')}
-                        </Button>
-                    </Link>
-                </Col>
-            }
+            <Col colSize={{ sm: 6, xs: 12 }} pt={{ sm: 1, xs: 0 }} tAlign={{ sm: 'right', xs: 'left' }}> 
+                <Link href="/manager/communities/add" passHref>
+                    <Button icon="plus">
+                        {t('addCommunity')}
+                    </Button>
+                </Link>
+            </Col>
         </Row>
     )
 };

--- a/src/views/EditCommunity/EditCommunity.tsx
+++ b/src/views/EditCommunity/EditCommunity.tsx
@@ -1,5 +1,5 @@
 import { Box, Display, ViewContainer } from '@impact-market/ui';
-import { addCommunitySchema } from '../../utils/communities';
+import { editCommunitySchema } from '../../utils/communities';
 import { getImage } from '../../utils/images';
 import { selectCurrentUser } from '../../state/slices/auth';
 import { selectRates } from '../../state/slices/rates';
@@ -99,7 +99,7 @@ const EditCommunity: React.FC<{ isLoading?: boolean }> = (props) => {
         setValue,
         reset
     } = useForm({
-        resolver: useYupValidationResolver(addCommunitySchema)
+        resolver: useYupValidationResolver(editCommunitySchema)
     });
 
     useEffect(() => {

--- a/src/views/EditCommunity/EditPending.tsx
+++ b/src/views/EditCommunity/EditPending.tsx
@@ -3,7 +3,7 @@
 import { Box, Button, Display, toast } from '@impact-market/ui';
 import { Community, Contract, useEditPendingCommunityMutation, useGetCommunityPreSignedMutation } from '../../api/community';
 import { SubmitHandler, useForm, useWatch } from "react-hook-form";
-import { addCommunitySchema } from '../../utils/communities';
+import { editCommunitySchema } from '../../utils/communities';
 import { frequencyToNumber, frequencyToText } from '@impact-market/utils';
 import { getCountryCurrency, getCountryNameFromInitials } from '../../utils/countries';
 import { getImage } from '../../utils/images';
@@ -61,7 +61,7 @@ const EditPending: React.FC<{ community: Community, contract: Contract }> = prop
             maxClaim: contract?.maxClaim || '',
             name: community?.name || ''
         },
-        resolver: useYupValidationResolver(addCommunitySchema)
+        resolver: useYupValidationResolver(editCommunitySchema)
     });
 
     // We can only edit this Community if: the current User is the one who created OR the current User is an Ambassador for this Community


### PR DESCRIPTION
<!---
All PRs should be reviewed in terms of code by at least one person and manually tested by another.

Complete what's missing.
-->

This PR fixes #297 
## Changes

- Show Add Community to everyone:
Now, it's possible to start to add a community without being logged in.
After the community's data have been submitted, the user must connect to the wallet. If the user already has an account (with name, email and picture), and is not in an existing community (as a manager or beneficiary), the new community is normally added. If the user doesn't have an account (no name, email and picture), it should prompt a modal to fill those inputs and the user data is automatically updated with the new community.

## Tests

- [x] Tested on mobile
- [x] Tested on dektop

This PR should be manually tested by @PauloSousapt @obernardovieira , included on reviewers.
